### PR TITLE
Replace WinRAR to PowerShell

### DIFF
--- a/Maya CSharp Command With Undo/Maya CSharp Command With Undo.csproj
+++ b/Maya CSharp Command With Undo/Maya CSharp Command With Undo.csproj
@@ -83,7 +83,7 @@ if exist "$(SolutionDir)Output\$(ProjectName).zip" del "$(SolutionDir)Output\$(P
 del *.* /s /q &gt; nul
 copy /Y "$(ProjectDir)myCommand.cs" . &gt;nul
 copy /Y "$(ProjectDir)Template Data\*.*" . &gt;nul
-"C:\Program Files\WinRAR\WinRAR.exe" a -r "..\$(ProjectName).zip" *.* &gt;nul</PostBuildEvent>
+powershell compress-archive -Force .\* '..\$(ProjectName).zip' &gt;nul</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Maya CSharp Command/Maya CSharp Command.csproj
+++ b/Maya CSharp Command/Maya CSharp Command.csproj
@@ -83,7 +83,7 @@ if exist "$(SolutionDir)Output\$(ProjectName).zip" del "$(SolutionDir)Output\$(P
 del *.* /s /q &gt; nul
 copy /Y "$(ProjectDir)myCommand.cs" . &gt;nul
 copy /Y "$(ProjectDir)Template Data\*.*" . &gt;nul
-"C:\Program Files\WinRAR\WinRAR.exe" a -r "..\$(ProjectName).zip" *.* &gt;nul</PostBuildEvent>
+powershell compress-archive -Force .\* '..\$(ProjectName).zip' &gt;nul</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Maya CSharp Node/Maya CSharp Node.csproj
+++ b/Maya CSharp Node/Maya CSharp Node.csproj
@@ -83,7 +83,7 @@ if exist "$(SolutionDir)Output\$(ProjectName).zip" del "$(SolutionDir)Output\$(P
 del *.* /s /q &gt; nul
 copy /Y "$(ProjectDir)myNode.cs" . &gt;nul
 copy /Y "$(ProjectDir)Template Data\*.*" . &gt;nul
-"C:\Program Files\WinRAR\WinRAR.exe" a -r "..\$(ProjectName).zip" *.* &gt;nul</PostBuildEvent>
+powershell compress-archive -Force .\* '..\$(ProjectName).zip' &gt;nul</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Maya CSharp plug-in/Maya CSharp plug-in.csproj
+++ b/Maya CSharp plug-in/Maya CSharp plug-in.csproj
@@ -124,7 +124,7 @@ copy /Y "$(ProjectDir)myNode.resx" . &gt;nul
 copy /Y "$(ProjectDir)myNode.Designer.cs" . &gt;nul
 copy /Y "$(ProjectDir)Properties\AssemblyInfo.cs" .\Properties &gt;nul
 copy /Y "$(ProjectDir)Template Data\*.*" . &gt;nul
-"C:\Program Files\WinRAR\WinRAR.exe" a -r "..\$(ProjectName).zip" *.*  &gt;nul</PostBuildEvent>
+powershell compress-archive -Force .\* '..\$(ProjectName).zip' &gt;nul</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
# Overview

This PR brings the following benefits:

- Currently, building without WinRAR will fail. WinRAR is required for build.  My PR fixes this.
   - The README doesn't state that the build requirements require WinRAR to be installed.
- Anyone can build `Maya plug-in Wizards`, even if they don't have WinRAR.
   - My pr replaced WinRAR to `powershell compress-archive` in PostBuildEvent  of csproj. 
   - [compress-archive](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.archive/compress-archive?view=powershell-5.1) is included in PowerShell v5.1.
   - PowerShell v5.1 was released along with the [Windows 10 Anniversary Update](https://blogs.windows.com/windowsexperience/2016/08/02/how-to-get-the-windows-10-anniversary-update/) on August 2, 2016

# Steps to Reproduce the Problem

**State before correction**

Steps is here:

1. git clone https://github.com/ADN-DevTech/Maya-Net-Wizards.git
2. Open `Maya plug-in Wizards.sln`
3. Build solution

After following this step, Visual Studio will display the following a log:

```
Build started...
1>------ Build started: Project: Maya CSharp plug-in, Configuration: Debug Any CPU ------
2>------ Build started: Project: Maya CSharp Node, Configuration: Debug Any CPU ------
3>------ Build started: Project: Maya CSharp Command, Configuration: Debug Any CPU ------
4>------ Build started: Project: Maya CSharp Command With Undo, Configuration: Debug Any CPU ------
2>  Maya CSharp Node -> C:\git\Maya-Net-Wizards\Maya CSharp Node\bin\Debug\Maya CSharp Node.dll
3>  Maya CSharp Command -> C:\git\Maya-Net-Wizards\Maya CSharp Command\bin\Debug\Maya CSharp Node.dll
1>  Maya CSharp plug-in -> C:\git\Maya-Net-Wizards\Maya CSharp plug-in\bin\Debug\Maya CSharp plug-in.dll
3>  A subdirectory or file C:\git\Maya-Net-Wizards\Output\Maya CSharp Command already exists.
2>  The system cannot find the path specified.
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: The command "mkdir "C:\git\Maya-Net-Wizards\Output\Maya CSharp Node" 2>nul
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: cd "C:\git\Maya-Net-Wizards\Output\Maya CSharp Node"
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: if exist "C:\git\Maya-Net-Wizards\Output\Maya CSharp Node.zip" del "C:\git\Maya-Net-Wizards\Output\Maya CSharp Node.zip"
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: del *.* /s /q > nul
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp Node\myNode.cs" . >nul
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp Node\Template Data\*.*" . >nul
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: "C:\Program Files\WinRAR\WinRAR.exe" a -r "..\Maya CSharp Node.zip" *.* >nul" exited with code 3.
3>  The system cannot find the path specified.
3>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: The command "mkdir "C:\git\Maya-Net-Wizards\Output\Maya CSharp Command"
3>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: cd "C:\git\Maya-Net-Wizards\Output\Maya CSharp Command"
3>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: if exist "C:\git\Maya-Net-Wizards\Output\Maya CSharp Command.zip" del "C:\git\Maya-Net-Wizards\Output\Maya CSharp Command.zip"
3>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: del *.* /s /q > nul
3>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp Command\myCommand.cs" . >nul
3>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp Command\Template Data\*.*" . >nul
3>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: "C:\Program Files\WinRAR\WinRAR.exe" a -r "..\Maya CSharp Command.zip" *.* >nul" exited with code 3.
1>  The system cannot find the path specified.
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: The command "mkdir "C:\git\Maya-Net-Wizards\Output\Maya CSharp plug-in" 2>nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: mkdir "C:\git\Maya-Net-Wizards\Output\Maya CSharp plug-in\Properties" 2>nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: cd "C:\git\Maya-Net-Wizards\Output\Maya CSharp plug-in"
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: if exist "C:\git\Maya-Net-Wizards\Output\Maya CSharp plug-in.zip" del "C:\git\Maya-Net-Wizards\Output\Maya CSharp plug-in.zip"
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: del *.* /s /q > nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\Maya CSharp plug-in - Copy.csproj" ".\Maya CSharp plug-in.csproj" >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\myPlugin.cs" . >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\myCommand.cs" . >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\myCommand.resx" . >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\myCommand.Designer.cs" . >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\myNode.cs" . >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\myNode.resx" . >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\myNode.Designer.cs" . >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\Properties\AssemblyInfo.cs" .\Properties >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp plug-in\Template Data\*.*" . >nul
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: "C:\Program Files\WinRAR\WinRAR.exe" a -r "..\Maya CSharp plug-in.zip" *.*  >nul" exited with code 3.
4>  Maya CSharp Command With Undo -> C:\git\Maya-Net-Wizards\Maya CSharp Command With Undo\bin\Debug\Maya CSharp Node.dll
4>  The system cannot find the path specified.
4>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: The command "mkdir "C:\git\Maya-Net-Wizards\Output\Maya CSharp Command With Undo" 2>nul
4>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: cd "C:\git\Maya-Net-Wizards\Output\Maya CSharp Command With Undo"
4>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: if exist "C:\git\Maya-Net-Wizards\Output\Maya CSharp Command With Undo.zip" del "C:\git\Maya-Net-Wizards\Output\Maya CSharp Command With Undo.zip"
4>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: del *.* /s /q > nul
4>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp Command With Undo\myCommand.cs" . >nul
4>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: copy /Y "C:\git\Maya-Net-Wizards\Maya CSharp Command With Undo\Template Data\*.*" . >nul
4>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5576,5): error MSB3073: "C:\Program Files\WinRAR\WinRAR.exe" a -r "..\Maya CSharp Command With Undo.zip" *.* >nul" exited with code 3.
========== Build: 0 succeeded, 4 failed, 0 up-to-date, 0 skipped ==========
```

# Note

In China, WinRAR is free for personal use. However, some people may need to buy a license.
Therefore, WinRAR is not always installed on Windows PC.

[WinRAR - 压缩软件 老牌压缩软件知名产品 经典装机软件之一](https://www.winrar.com.cn/about.htm)

```
我们很荣幸地宣布，经过多年的努力，现在终于向中国的个人用户提供一款完全免费的WinRAR简体中文版了。
...
随着全新的 WinRAR免费非商用个人版本的发布，我们为中国的每一个用户提供安全、可靠、出色的压缩软件。
```

