### PR TITLE
Add tag to project template

### DIFF
--- a/Maya CSharp plug-in/Template Data/MyTemplate.vstemplate
+++ b/Maya CSharp plug-in/Template Data/MyTemplate.vstemplate
@@ -13,6 +13,9 @@
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>
     <Icon>__TemplateIcon.ico</Icon>
     <PreviewImage>__PreviewImage.ico</PreviewImage>
+    <LanguageTag>csharp</LanguageTag>
+    <PlatformTag>windows</PlatformTag>
+    <ProjectTypeTag>library</ProjectTypeTag>
 	<RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
   </TemplateData>
   <TemplateContent>


### PR DESCRIPTION
Added language tag, platform tag and project tag to project template.
Those tags are visible in Visual Studio 2019 v16.1 and later.

| Before modification (Current) | After modification |
----|---- 
| ![before](https://user-images.githubusercontent.com/359823/140614874-5644c1fd-93ef-4656-8b05-d7487abc1d98.jpg) | ![after](https://user-images.githubusercontent.com/359823/140614878-365c6ce7-5869-4de1-b8de-64abf520037d.jpg) |

See also:

- [Add or edit tags on project templates - Visual Studio (Windows) | Microsoft Docs](https://docs.microsoft.com/en-us/visualstudio/ide/template-tags?view=vs-2019)
- [Visual Studio 2019 version 16.1 Release Notes | Microsoft Docs](https://docs.microsoft.com/en-us/visualstudio/releases/2019/release-notes-v16.1#--visual-studio-2019-version-161)